### PR TITLE
Remove explicit dateutil pin to silence DeprecationWarning

### DIFF
--- a/actblue/actblue.py
+++ b/actblue/actblue.py
@@ -20,7 +20,6 @@ from flask import (
     request,
 )
 from nameparser import HumanName
-import dateutil
 import pytz
 
 from common.mobile_commons import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ Flask==1.0.3
 gunicorn==19.9.0
 nameparser==1.0.3
 phonenumbers==8.10.13
-python-dateutil==2.6.0
 pytz==2019.2
 xmltodict==0.12.0


### PR DESCRIPTION
When running the tests locally, the output of `make test` contained the warning
```
=============================== warnings summary ===============================
/usr/local/lib/python3.7/site-packages/dateutil/parser.py:587
  /usr/local/lib/python3.7/site-packages/dateutil/parser.py:587: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if (isinstance(tzinfos, collections.Callable) or

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================== 5 passed, 1 warnings in 0.45 seconds =====================
```
I noticed that dateutil is not used anywhere in the first-party code - by removing the explicit pin I was able to silence the warning, which makes the pytest output less noisy.